### PR TITLE
Added more columns to product summary

### DIFF
--- a/sql/app/home/get_product_summary.sql
+++ b/sql/app/home/get_product_summary.sql
@@ -10,14 +10,26 @@ RETURNS TABLE
   product_key_string                    text,
   product_info                          text,
   product_info_details                  text,
+  product_status_enum                   product_status_type,
+  product_status                        integer,
   floor                                 numeric,
   ceiling                               numeric,
   leverage                              numeric,
   capital_efficiency                    numeric,
   capacity                              numeric,
   commitment                            numeric,
+  available_for_underwriting            numeric,
   utilization_ratio                     numeric,
-  reassurance                           numeric
+  reassurance                           numeric,
+  tvl                                   numeric,
+  coverage_lag                          numeric,
+  supports_products                     boolean,
+  requires_whitelist                    boolean,
+  min_reporting_stake                   numeric,
+  active_incident_date                  integer,
+  reporter_commission                   integer,
+  reporting_period                      integer,
+  claim_platform_fee                    integer
 )
 AS
 $$
@@ -33,29 +45,86 @@ BEGIN
     product_key_string                text,
     product_info                      text,
     product_info_details              text,
+    product_status_enum               product_status_type,
+    product_status                    integer,
     floor                             numeric DEFAULT(0),
     ceiling                           numeric DEFAULT(0),
     leverage                          numeric DEFAULT(0),
     capital_efficiency                numeric DEFAULT(0),
     capacity                          numeric DEFAULT(0),
     commitment                        numeric DEFAULT(0),
+    available_for_underwriting        numeric DEFAULT(0),
     utilization_ratio                 numeric,
-    reassurance                       numeric DEFAULT(0)
+    reassurance                       numeric DEFAULT(0),
+    tvl                               numeric DEFAULT(0),
+    coverage_lag                      numeric DEFAULT(0),
+    supports_products                 boolean DEFAULT(false),
+    requires_whitelist                boolean DEFAULT(false),
+    min_reporting_stake               numeric,
+    active_incident_date              integer,
+    reporter_commission               integer,
+    reporting_period                  integer,
+    claim_platform_fee                integer
   ) ON COMMIT DROP;
   
-  INSERT INTO _get_product_summary_result(chain_id, cover_key, cover_key_string, product_key, product_key_string, capital_efficiency)
+  INSERT INTO _get_product_summary_result
+  (
+    chain_id,
+    cover_key,
+    cover_key_string,
+    product_key,
+    product_key_string,
+    capital_efficiency,
+    tvl,
+    coverage_lag,
+    floor,
+    ceiling,
+    reporter_commission,
+    claim_platform_fee,
+    product_status_enum,
+    min_reporting_stake,
+    active_incident_date
+  )
   SELECT
     config_product_view.chain_id,
     config_product_view.cover_key,
     bytes32_to_string(config_product_view.cover_key),
     config_product_view.product_key,
     bytes32_to_string(config_product_view.product_key),
-    config_product_view.capital_efficiency
+    config_product_view.capital_efficiency,
+    get_tvl_till_date(config_product_view.chain_id, config_product_view.cover_key, 'infinity'),
+    get_coverage_lag(config_product_view.chain_id, config_product_view.cover_key),
+    get_policy_floor(config_product_view.chain_id, config_product_view.cover_key),
+    get_policy_ceiling(config_product_view.chain_id, config_product_view.cover_key),
+    get_reporter_commission(config_product_view.chain_id),
+    get_claim_platform_fee(config_product_view.chain_id),
+    get_active_product_status(config_product_view.chain_id, config_product_view.cover_key, config_product_view.product_key),
+    get_min_first_reporting_stake(config_product_view.chain_id, config_product_view.cover_key),
+    get_active_incident_date(config_product_view.chain_id, config_product_view.cover_key, config_product_view.product_key)
   FROM config_product_view
   WHERE config_product_view.chain_id IN
   (
     SELECT DISTINCT core.transactions.chain_id
     FROM core.transactions
+  );
+
+  UPDATE _get_product_summary_result
+  SET requires_whitelist = 
+  (
+    SELECT cover.cover_created.requires_whitelist
+    FROM cover.cover_created
+    WHERE cover.cover_created.chain_id = _get_product_summary_result.chain_id
+    AND cover.cover_created.cover_key = _get_product_summary_result.cover_key
+  );
+
+  UPDATE _get_product_summary_result
+  SET reporting_period = 
+  (
+    SELECT config_cover_view.reporting_period
+    FROM config_cover_view
+    WHERE config_cover_view.chain_id = _get_product_summary_result.chain_id
+    AND config_cover_view.cover_key = _get_product_summary_result.cover_key
+    LIMIT 1
   );
   
   UPDATE _get_product_summary_result
@@ -77,15 +146,6 @@ BEGIN
   SET product_key = string_to_bytes32('')
   WHERE _get_product_summary_result.product_key IS NULL;
 
-  UPDATE _get_product_summary_result
-  SET
-    floor = config_cover_view.policy_floor,
-    ceiling = config_cover_view.policy_ceiling
-  FROM config_cover_view
-  WHERE config_cover_view.chain_id = _get_product_summary_result.chain_id
-  AND config_cover_view.cover_key = _get_product_summary_result.cover_key;
-  
-  
   UPDATE _get_product_summary_result
   SET capacity = capacity_view.capacity
   FROM capacity_view
@@ -113,9 +173,17 @@ BEGIN
   WHERE cover_commitment_view.chain_id = _get_product_summary_result.chain_id
   AND cover_commitment_view.cover_key = _get_product_summary_result.cover_key
   AND _get_product_summary_result.product_key IS NULL;
+
+  UPDATE _get_product_summary_result
+  SET 
+    available_for_underwriting = _get_product_summary_result.capacity - _get_product_summary_result.commitment,
+    product_status = array_length(enum_range(NULL, _get_product_summary_result.product_status_enum), 1) - 1;
   
   UPDATE _get_product_summary_result
   SET reassurance = get_reassurance_till_date(_get_product_summary_result.chain_id, _get_product_summary_result.cover_key, 'infinity');
+  
+  UPDATE _get_product_summary_result
+  SET tvl = get_tvl_till_date(_get_product_summary_result.chain_id, _get_product_summary_result.cover_key, 'infinity');
   
   UPDATE _get_product_summary_result
   SET utilization_ratio = _get_product_summary_result.commitment / _get_product_summary_result.capacity;
@@ -146,6 +214,10 @@ BEGIN
   UPDATE _get_product_summary_result
   SET product_key = NULL
   WHERE _get_product_summary_result.product_key = string_to_bytes32('');
+  
+  UPDATE _get_product_summary_result
+  SET supports_products = is_diversified(_get_product_summary_result.chain_id, _get_product_summary_result.cover_key)
+  WHERE _get_product_summary_result.product_key IS NULL;
 
   RETURN QUERY
   SELECT * FROM _get_product_summary_result;


### PR DESCRIPTION
Added following fields
- `reassurance`
- `tvl`
- `coverage_lag`
- `supports_products`
- `requires_whitelist`
- `min_reporting_stake`
- `active_incident_date`
- `reporter_commission`
- `reporting_period`
- `claim_platform_fee`
- `available_for_underwritin`
- `product_status_enum`
- `product_status`