### PR TITLE
# Added Datewise Liquidity Summary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,6 +80,7 @@
     "synthetix",
     "trunc",
     "unliked",
+    "UNLOGGED",
     "Unstakable",
     "unstake",
     "Unstaken",

--- a/sql/app/home/get_datewise_liquidity_summary.sql
+++ b/sql/app/home/get_datewise_liquidity_summary.sql
@@ -1,0 +1,125 @@
+CREATE OR REPLACE FUNCTION get_datewise_liquidity_summary()
+RETURNS TABLE
+(
+  id                                                        bigint,
+  date                                                      TIMESTAMP WITH TIME ZONE,
+  total_liquidity                                           numeric,
+  total_capacity                                            numeric,
+  total_covered                                             numeric,
+  total_cover_fee                                           numeric,
+  total_purchase_count                                      numeric  
+)
+SECURITY DEFINER
+AS
+$$
+  DECLARE _start                                            TIMESTAMP WITH TIME ZONE;
+  DECLARE _end                                              TIMESTAMP WITH TIME ZONE;
+BEGIN
+  CREATE UNLOGGED TABLE IF NOT EXISTS public.datewise_liquidity_summary
+  (
+    id                                                      BIGSERIAL,
+    chain_id                                                integer,
+    date                                                    TIMESTAMP WITH TIME ZONE,
+    total_liquidity                                         numeric,
+    total_capacity                                          numeric,
+    total_covered                                           numeric,
+    total_cover_fee                                         numeric,
+    total_purchase_count                                    numeric  
+  );
+
+  ALTER TABLE public.datewise_liquidity_summary OWNER TO writeuser;
+
+  CREATE INDEX IF NOT EXISTS datewise_liquidity_summary_date_inx
+  ON public.datewise_liquidity_summary(date);
+
+  WITH date_ranges
+  AS
+  (
+    SELECT
+      min(block_timestamp) AS min,
+      max(block_timestamp) AS max
+    FROM core.transactions
+  )
+  SELECT to_timestamp(min), to_timestamp(max)
+  INTO _start, _end
+  FROM date_ranges;
+
+
+  SELECT COALESCE(summary.max_date, _start)
+  INTO _start
+  FROM
+  (
+    SELECT MAX(datewise_liquidity_summary.date) AS max_date
+    FROM datewise_liquidity_summary
+  ) AS summary;
+
+  RAISE NOTICE 'Start date: %. End date: %', _start, _end;
+
+  WITH chains
+  AS
+  (
+    SELECT DISTINCT core.transactions.chain_id
+    FROM core.transactions
+  ),
+  dates
+  AS
+  (
+    SELECT date_trunc('day', dates)::date + interval '1 day' - interval '1 second' AS date
+    FROM generate_series(_start, _end, INTERVAL '1 days') AS dates
+  ),
+  chainwise
+  AS
+  (
+    SELECT DISTINCT chains.chain_id, dates.date
+    FROM chains
+    CROSS JOIN dates
+  )
+  INSERT INTO public.datewise_liquidity_summary(chain_id, date)
+  SELECT chainwise.chain_id, chainwise.date
+  FROM chainwise
+  LEFT JOIN public.datewise_liquidity_summary
+  ON chainwise.chain_id = public.datewise_liquidity_summary.chain_id
+  AND chainwise.date = public.datewise_liquidity_summary.date
+  WHERE public.datewise_liquidity_summary.chain_id IS NULL;
+
+  UPDATE public.datewise_liquidity_summary
+  SET total_liquidity = get_tvl_till_date(public.datewise_liquidity_summary.chain_id, public.datewise_liquidity_summary.date)
+  WHERE public.datewise_liquidity_summary.total_liquidity IS NULL;
+
+  UPDATE public.datewise_liquidity_summary
+  SET total_capacity = get_total_capacity_by_date(public.datewise_liquidity_summary.date)
+  WHERE public.datewise_liquidity_summary.total_capacity IS NULL;
+
+  UPDATE public.datewise_liquidity_summary
+  SET total_covered = get_total_covered_till_date(public.datewise_liquidity_summary.date)
+  WHERE public.datewise_liquidity_summary.total_covered IS NULL;
+
+  UPDATE public.datewise_liquidity_summary
+  SET total_cover_fee = sum_cover_fee_earned_during('-infinity', public.datewise_liquidity_summary.date)
+  WHERE public.datewise_liquidity_summary.total_cover_fee IS NULL;
+
+  UPDATE public.datewise_liquidity_summary
+  SET total_purchase_count = count_cover_purchase_during('-infinity', public.datewise_liquidity_summary.date)
+  WHERE public.datewise_liquidity_summary.total_purchase_count IS NULL;
+
+  RETURN QUERY
+  SELECT
+    row_number() OVER(ORDER BY public.datewise_liquidity_summary.date) AS id,
+    public.datewise_liquidity_summary.date,
+    SUM(public.datewise_liquidity_summary.total_liquidity) AS total_liquidity,
+    SUM(public.datewise_liquidity_summary.total_capacity) AS total_capacity,
+    SUM(public.datewise_liquidity_summary.total_covered) AS total_covered,
+    SUM(public.datewise_liquidity_summary.total_cover_fee) AS total_cover_fee,
+    SUM(public.datewise_liquidity_summary.total_purchase_count) AS total_purchase_count
+  FROM public.datewise_liquidity_summary
+  GROUP BY public.datewise_liquidity_summary.date;
+END
+$$
+LANGUAGE plpgsql;
+
+ALTER FUNCTION get_datewise_liquidity_summary() OWNER TO writeuser;
+ALTER TABLE core.transactions owner to writeuser;
+ALTER TABLE IF EXISTS public.datewise_liquidity_summary owner to writeuser;
+
+-- SELECT * FROM get_datewise_liquidity_summary();
+

--- a/sql/app/home/get_historical_apr_by_cover_chart_data.sql
+++ b/sql/app/home/get_historical_apr_by_cover_chart_data.sql
@@ -58,7 +58,7 @@ BEGIN
 
   UPDATE _get_historical_apr_chart_data_result
   SET
-    policy_fee_earned = sum_cover_purchased_during(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.cover_key, _get_historical_apr_chart_data_result.start_date, _get_historical_apr_chart_data_result.end_date),
+    policy_fee_earned = sum_cover_fee_earned_during(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.cover_key, _get_historical_apr_chart_data_result.start_date, _get_historical_apr_chart_data_result.end_date),
     duration = _get_historical_apr_chart_data_result.end_date - _get_historical_apr_chart_data_result.start_date,
     end_balance       = get_tvl_till_date(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.cover_key, _get_historical_apr_chart_data_result.end_date);
   
@@ -77,6 +77,8 @@ BEGIN
 END
 $$
 LANGUAGE plpgsql;
+
+ALTER FUNCTION get_historical_apr_by_cover_chart_data() OWNER TO writeuser;
 
 -- SELECT * FROM get_historical_apr_by_cover_chart_data() ORDER BY APR DESC;
 

--- a/sql/app/home/get_historical_apr_chart_data.sql
+++ b/sql/app/home/get_historical_apr_chart_data.sql
@@ -53,7 +53,7 @@ BEGIN
 
   UPDATE _get_historical_apr_chart_data_result
   SET
-    policy_fee_earned = sum_cover_purchased_during(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.start_date, _get_historical_apr_chart_data_result.end_date),
+    policy_fee_earned = sum_cover_fee_earned_during(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.start_date, _get_historical_apr_chart_data_result.end_date),
     duration = _get_historical_apr_chart_data_result.end_date - _get_historical_apr_chart_data_result.start_date;
   
   UPDATE _get_historical_apr_chart_data_result
@@ -71,5 +71,7 @@ BEGIN
 END
 $$
 LANGUAGE plpgsql;
+
+ALTER FUNCTION get_historical_apr_chart_data() OWNER TO writeuser;
 
 --SELECT * FROM get_historical_apr_chart_data();

--- a/sql/base/003-functions/count_cover_purchase_during.sql
+++ b/sql/base/003-functions/count_cover_purchase_during.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION sum_cover_purchased_during
+CREATE OR REPLACE FUNCTION count_cover_purchase_during
 (
   _start                                      TIMESTAMP WITH TIME ZONE,
   _end                                        TIMESTAMP WITH TIME ZONE
@@ -9,13 +9,10 @@ AS
 $$
   DECLARE _result numeric;
 BEGIN
-  SELECT
-    SUM(get_stablecoin_value(policy.cover_purchased.chain_id, policy.cover_purchased.fee))
-  INTO
-    _result
+  SELECT COUNT(*)
+  INTO _result
   FROM policy.cover_purchased
-  WHERE to_timestamp(policy.cover_purchased.block_timestamp)
-  BETWEEN _start AND _end;
+  WHERE to_timestamp(policy.cover_purchased.block_timestamp) BETWEEN _start AND _end;
 
   RETURN COALESCE(_result, 0);
 END
@@ -23,7 +20,7 @@ $$
 LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION sum_cover_purchased_during
+CREATE OR REPLACE FUNCTION count_cover_purchase_during
 (
   _chain_id                                   uint256,
   _start                                      TIMESTAMP WITH TIME ZONE,
@@ -35,21 +32,18 @@ AS
 $$
   DECLARE _result numeric;
 BEGIN
-  SELECT
-    SUM(get_stablecoin_value(policy.cover_purchased.chain_id, policy.cover_purchased.fee))
-  INTO
-    _result
+  SELECT COUNT(*)
+  INTO _result
   FROM policy.cover_purchased
   WHERE policy.cover_purchased.chain_id = _chain_id
-  AND to_timestamp(policy.cover_purchased.block_timestamp)
-  BETWEEN _start AND _end;
+  AND to_timestamp(policy.cover_purchased.block_timestamp) BETWEEN _start AND _end;
 
   RETURN COALESCE(_result, 0);
 END
 $$
 LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION sum_cover_purchased_during
+CREATE OR REPLACE FUNCTION count_cover_purchase_during
 (
   _chain_id                                   uint256,
   _cover_key                                  bytes32,
@@ -62,17 +56,19 @@ AS
 $$
   DECLARE _result numeric;
 BEGIN
-  SELECT
-    SUM(get_stablecoin_value(policy.cover_purchased.chain_id, policy.cover_purchased.fee))
-  INTO
-    _result
+  SELECT COUNT(*)
+  INTO _result
   FROM policy.cover_purchased
   WHERE policy.cover_purchased.chain_id = _chain_id
   AND policy.cover_purchased.cover_key = _cover_key
-  AND to_timestamp(policy.cover_purchased.block_timestamp)
-  BETWEEN _start AND _end;
+  AND to_timestamp(policy.cover_purchased.block_timestamp) BETWEEN _start AND _end;
 
   RETURN COALESCE(_result, 0);
 END
 $$
 LANGUAGE plpgsql;
+
+
+ALTER FUNCTION count_cover_purchase_during(TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION count_cover_purchase_during(uint256, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION count_cover_purchase_during(uint256, bytes32, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;

--- a/sql/base/003-functions/get_capacity_till_date.sql
+++ b/sql/base/003-functions/get_capacity_till_date.sql
@@ -48,21 +48,21 @@ BEGIN
       is_diversified(chain_id, cover_key) AS diversified,
       product_key,
       bytes32_to_string(product_key) AS product,
-      get_cover_capacity_till(chain_id, cover_key, product_key, 'infinity') AS capacity,
-      format_stablecoin(get_cover_capacity_till(chain_id, cover_key, product_key, 'infinity')) AS formatted_capacity
+      get_cover_capacity_till(chain_id, cover_key, product_key, _date) AS capacity,
+      format_stablecoin(get_cover_capacity_till(chain_id, cover_key, product_key, _date)) AS formatted_capacity
     FROM products
   )
   SELECT SUM(capacity)
   INTO _capacity
   FROM summary
   WHERE 1 = 1
-  AND NOT (diversified = true AND product_key != string_to_bytes32(''))
-  ORDER BY product;
+  AND NOT (diversified = true AND product_key != string_to_bytes32(''));
 
   RETURN COALESCE(_capacity, 0);
 END
 $$
 LANGUAGE plpgsql;
 
+ALTER FUNCTION get_total_capacity_by_date(TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
 
 --SELECT get_total_capacity_by_date('infinity')

--- a/sql/base/003-functions/get_total_covered_till_date.sql
+++ b/sql/base/003-functions/get_total_covered_till_date.sql
@@ -1,0 +1,74 @@
+CREATE OR REPLACE FUNCTION get_total_covered_till_date
+(
+  _date                                     TIMESTAMP WITH TIME ZONE
+)
+RETURNS numeric
+STABLE
+AS
+$$
+  DECLARE _result numeric;
+BEGIN
+  SELECT SUM(get_stablecoin_value(chain_id, amount_to_cover))
+  INTO _result
+  FROM policy.cover_purchased
+  WHERE to_timestamp(expires_on) <= _date;
+
+  RETURN COALESCE(_result, 0);
+END
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION get_total_covered_till_date
+(
+  _chain_id                                 uint256,
+  _date                                     TIMESTAMP WITH TIME ZONE
+)
+RETURNS numeric
+STABLE
+AS
+$$
+  DECLARE _result numeric;
+BEGIN
+  SELECT SUM(get_stablecoin_value(chain_id, amount_to_cover))
+  INTO _result
+  FROM policy.cover_purchased
+  WHERE chain_id = _chain_id
+  AND to_timestamp(expires_on) <= _date;
+
+  RETURN COALESCE(_result, 0);
+END
+$$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION get_total_covered_till_date
+(
+  _chain_id                                 uint256,
+  _cover_key                                bytes32,
+  _date                                     TIMESTAMP WITH TIME ZONE
+)
+RETURNS numeric
+STABLE
+AS
+$$
+  DECLARE _result numeric;
+BEGIN
+  SELECT SUM(get_stablecoin_value(chain_id, amount_to_cover))
+  INTO _result
+  FROM policy.cover_purchased
+  WHERE chain_id = _chain_id
+  AND cover_key = _cover_key
+  AND to_timestamp(expires_on) <= _date;
+
+  RETURN COALESCE(_result, 0);
+END
+$$
+LANGUAGE plpgsql;
+
+ALTER FUNCTION get_total_covered_till_date(TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_total_covered_till_date(uint256, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_total_covered_till_date(uint256, bytes32, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+
+-- SELECT * FROM get_total_covered_till_date('2021-01-01'::TIMESTAMP WITH TIME ZONE);
+-- SELECT * FROM get_total_covered_till_date(1, '0x1234'::bytes32, '2021-01-01'::TIMESTAMP WITH TIME ZONE);
+-- SELECT * FROM get_total_covered_till_date(1, '2021-01-01'::TIMESTAMP WITH TIME ZONE);

--- a/sql/base/003-functions/sum_cover_fee_earned_during.sql
+++ b/sql/base/003-functions/sum_cover_fee_earned_during.sql
@@ -1,0 +1,83 @@
+CREATE OR REPLACE FUNCTION sum_cover_fee_earned_during
+(
+  _start                                      TIMESTAMP WITH TIME ZONE,
+  _end                                        TIMESTAMP WITH TIME ZONE
+)
+RETURNS numeric
+STABLE
+AS
+$$
+  DECLARE _result numeric;
+BEGIN
+  SELECT
+    SUM(get_stablecoin_value(policy.cover_purchased.chain_id, policy.cover_purchased.fee))
+  INTO
+    _result
+  FROM policy.cover_purchased
+  WHERE to_timestamp(policy.cover_purchased.block_timestamp)
+  BETWEEN _start AND _end;
+
+  RETURN COALESCE(_result, 0);
+END
+$$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION sum_cover_fee_earned_during
+(
+  _chain_id                                   uint256,
+  _start                                      TIMESTAMP WITH TIME ZONE,
+  _end                                        TIMESTAMP WITH TIME ZONE
+)
+RETURNS numeric
+STABLE
+AS
+$$
+  DECLARE _result numeric;
+BEGIN
+  SELECT
+    SUM(get_stablecoin_value(policy.cover_purchased.chain_id, policy.cover_purchased.fee))
+  INTO
+    _result
+  FROM policy.cover_purchased
+  WHERE policy.cover_purchased.chain_id = _chain_id
+  AND to_timestamp(policy.cover_purchased.block_timestamp)
+  BETWEEN _start AND _end;
+
+  RETURN COALESCE(_result, 0);
+END
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sum_cover_fee_earned_during
+(
+  _chain_id                                   uint256,
+  _cover_key                                  bytes32,
+  _start                                      TIMESTAMP WITH TIME ZONE,
+  _end                                        TIMESTAMP WITH TIME ZONE
+)
+RETURNS numeric
+STABLE
+AS
+$$
+  DECLARE _result numeric;
+BEGIN
+  SELECT
+    SUM(get_stablecoin_value(policy.cover_purchased.chain_id, policy.cover_purchased.fee))
+  INTO
+    _result
+  FROM policy.cover_purchased
+  WHERE policy.cover_purchased.chain_id = _chain_id
+  AND policy.cover_purchased.cover_key = _cover_key
+  AND to_timestamp(policy.cover_purchased.block_timestamp)
+  BETWEEN _start AND _end;
+
+  RETURN COALESCE(_result, 0);
+END
+$$
+LANGUAGE plpgsql;
+
+
+ALTER FUNCTION sum_cover_fee_earned_during(TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION sum_cover_fee_earned_during(uint256, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION sum_cover_fee_earned_during(uint256, bytes32, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;


### PR DESCRIPTION
- Added function `get_datewise_liquidity_summary`
- For brevity, renamed the function `sum_cover_purchased_during` to `sum_cover_fee_earned_during`
- Added helper functions `count_cover_purchase_during` and `get_total_covered_till_date`
- Fixed bug in `get_total_capacity_by_date` function

## Query

```sql
DO
$$
BEGIN
  IF EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'sum_cover_purchased_during' AND pronargs = 2) THEN
    ALTER FUNCTION sum_cover_purchased_during(TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) RENAME TO sum_cover_fee_earned_during;
  END IF;

  IF EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'sum_cover_purchased_during' AND pronargs = 3) THEN
    ALTER FUNCTION sum_cover_purchased_during(uint256, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) RENAME TO sum_cover_fee_earned_during;
  END IF;

  IF EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'sum_cover_purchased_during' AND pronargs = 4) THEN
    ALTER FUNCTION sum_cover_purchased_during(uint256, bytes32, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) RENAME TO sum_cover_fee_earned_during;
  END IF;
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION sum_cover_fee_earned_during(TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION sum_cover_fee_earned_during(uint256, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION sum_cover_fee_earned_during(uint256, bytes32, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;

CREATE OR REPLACE FUNCTION get_total_covered_till_date
(
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT SUM(get_stablecoin_value(chain_id, amount_to_cover))
  INTO _result
  FROM policy.cover_purchased
  WHERE to_timestamp(expires_on) <= _date;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;

CREATE OR REPLACE FUNCTION get_total_covered_till_date
(
  _chain_id                                 uint256,
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT SUM(get_stablecoin_value(chain_id, amount_to_cover))
  INTO _result
  FROM policy.cover_purchased
  WHERE chain_id = _chain_id
  AND to_timestamp(expires_on) <= _date;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;

CREATE OR REPLACE FUNCTION get_total_covered_till_date
(
  _chain_id                                 uint256,
  _cover_key                                bytes32,
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT SUM(get_stablecoin_value(chain_id, amount_to_cover))
  INTO _result
  FROM policy.cover_purchased
  WHERE chain_id = _chain_id
  AND cover_key = _cover_key
  AND to_timestamp(expires_on) <= _date;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION get_total_covered_till_date(TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION get_total_covered_till_date(uint256, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION get_total_covered_till_date(uint256, bytes32, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;

CREATE OR REPLACE FUNCTION count_cover_purchase_during
(
  _start                                      TIMESTAMP WITH TIME ZONE,
  _end                                        TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT COUNT(*)
  INTO _result
  FROM policy.cover_purchased
  WHERE to_timestamp(policy.cover_purchased.block_timestamp) BETWEEN _start AND _end;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;

CREATE OR REPLACE FUNCTION count_cover_purchase_during
(
  _chain_id                                   uint256,
  _start                                      TIMESTAMP WITH TIME ZONE,
  _end                                        TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT COUNT(*)
  INTO _result
  FROM policy.cover_purchased
  WHERE policy.cover_purchased.chain_id = _chain_id
  AND to_timestamp(policy.cover_purchased.block_timestamp) BETWEEN _start AND _end;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;

CREATE OR REPLACE FUNCTION count_cover_purchase_during
(
  _chain_id                                   uint256,
  _cover_key                                  bytes32,
  _start                                      TIMESTAMP WITH TIME ZONE,
  _end                                        TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT COUNT(*)
  INTO _result
  FROM policy.cover_purchased
  WHERE policy.cover_purchased.chain_id = _chain_id
  AND policy.cover_purchased.cover_key = _cover_key
  AND to_timestamp(policy.cover_purchased.block_timestamp) BETWEEN _start AND _end;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION count_cover_purchase_during(TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION count_cover_purchase_during(uint256, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION count_cover_purchase_during(uint256, bytes32, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;

CREATE OR REPLACE FUNCTION get_datewise_liquidity_summary()
RETURNS TABLE
(
  id                                                        bigint,
  date                                                      TIMESTAMP WITH TIME ZONE,
  total_liquidity                                           numeric,
  total_capacity                                            numeric,
  total_covered                                             numeric,
  total_cover_fee                                           numeric,
  total_purchase_count                                      numeric
)
SECURITY DEFINER
AS
$$
  DECLARE _start                                            TIMESTAMP WITH TIME ZONE;
  DECLARE _end                                              TIMESTAMP WITH TIME ZONE;
BEGIN
  CREATE UNLOGGED TABLE IF NOT EXISTS public.datewise_liquidity_summary
  (
    id                                                      BIGSERIAL,
    chain_id                                                integer,
    date                                                    TIMESTAMP WITH TIME ZONE,
    total_liquidity                                         numeric,
    total_capacity                                          numeric,
    total_covered                                           numeric,
    total_cover_fee                                         numeric,
    total_purchase_count                                    numeric
  );

  ALTER TABLE public.datewise_liquidity_summary OWNER TO writeuser;

  CREATE INDEX IF NOT EXISTS datewise_liquidity_summary_date_inx
  ON public.datewise_liquidity_summary(date);

  WITH date_ranges
  AS
  (
    SELECT
      min(block_timestamp) AS min,
      max(block_timestamp) AS max
    FROM core.transactions
  )
  SELECT to_timestamp(min), to_timestamp(max)
  INTO _start, _end
  FROM date_ranges;

  SELECT COALESCE(summary.max_date, _start)
  INTO _start
  FROM
  (
    SELECT MAX(datewise_liquidity_summary.date) AS max_date
    FROM datewise_liquidity_summary
  ) AS summary;

  RAISE NOTICE 'Start date: %. End date: %', _start, _end;

  WITH chains
  AS
  (
    SELECT DISTINCT core.transactions.chain_id
    FROM core.transactions
  ),
  dates
  AS
  (
    SELECT date_trunc('day', dates)::date + interval '1 day' - interval '1 second' AS date
    FROM generate_series(_start, _end, INTERVAL '1 days') AS dates
  ),
  chainwise
  AS
  (
    SELECT DISTINCT chains.chain_id, dates.date
    FROM chains
    CROSS JOIN dates
  )
  INSERT INTO public.datewise_liquidity_summary(chain_id, date)
  SELECT chainwise.chain_id, chainwise.date
  FROM chainwise
  LEFT JOIN public.datewise_liquidity_summary
  ON chainwise.chain_id = public.datewise_liquidity_summary.chain_id
  AND chainwise.date = public.datewise_liquidity_summary.date
  WHERE public.datewise_liquidity_summary.chain_id IS NULL;

  UPDATE public.datewise_liquidity_summary
  SET total_liquidity = get_tvl_till_date(public.datewise_liquidity_summary.chain_id, public.datewise_liquidity_summary.date)
  WHERE public.datewise_liquidity_summary.total_liquidity IS NULL;

  UPDATE public.datewise_liquidity_summary
  SET total_capacity = get_total_capacity_by_date(public.datewise_liquidity_summary.date)
  WHERE public.datewise_liquidity_summary.total_capacity IS NULL;

  UPDATE public.datewise_liquidity_summary
  SET total_covered = get_total_covered_till_date(public.datewise_liquidity_summary.date)
  WHERE public.datewise_liquidity_summary.total_covered IS NULL;

  UPDATE public.datewise_liquidity_summary
  SET total_cover_fee = sum_cover_fee_earned_during('-infinity', public.datewise_liquidity_summary.date)
  WHERE public.datewise_liquidity_summary.total_cover_fee IS NULL;

  UPDATE public.datewise_liquidity_summary
  SET total_purchase_count = count_cover_purchase_during('-infinity', public.datewise_liquidity_summary.date)
  WHERE public.datewise_liquidity_summary.total_purchase_count IS NULL;

  RETURN QUERY
  SELECT
    row_number() OVER(ORDER BY public.datewise_liquidity_summary.date) AS id,
    public.datewise_liquidity_summary.date,
    SUM(public.datewise_liquidity_summary.total_liquidity) AS total_liquidity,
    SUM(public.datewise_liquidity_summary.total_capacity) AS total_capacity,
    SUM(public.datewise_liquidity_summary.total_covered) AS total_covered,
    SUM(public.datewise_liquidity_summary.total_cover_fee) AS total_cover_fee,
    SUM(public.datewise_liquidity_summary.total_purchase_count) AS total_purchase_count
  FROM public.datewise_liquidity_summary
  GROUP BY public.datewise_liquidity_summary.date;
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION get_datewise_liquidity_summary() OWNER TO writeuser;
ALTER TABLE core.transactions owner to writeuser;
ALTER TABLE IF EXISTS public.datewise_liquidity_summary owner to writeuser;
```