### PR TITLE
Fix volatility of functions

### DIFF
--- a/build/db.sql
+++ b/build/db.sql
@@ -6753,7 +6753,7 @@ CREATE OR REPLACE FUNCTION get_reassurance_till_date
   _date                                     TIMESTAMP WITH TIME ZONE
 )
 RETURNS numeric
-IMMUTABLE
+STABLE
 AS
 $$
   DECLARE _added numeric;
@@ -6780,7 +6780,7 @@ CREATE OR REPLACE FUNCTION get_reassurance_till_date
   _date                                     TIMESTAMP WITH TIME ZONE
 )
 RETURNS numeric
-IMMUTABLE
+STABLE
 AS
 $$
   DECLARE _added numeric;
@@ -6810,7 +6810,7 @@ CREATE OR REPLACE FUNCTION get_reassurance_till_date
   _date                                     TIMESTAMP WITH TIME ZONE
 )
 RETURNS numeric
-IMMUTABLE
+STABLE
 AS
 $$
   DECLARE _added numeric;
@@ -6835,8 +6835,11 @@ END
 $$
 LANGUAGE plpgsql;
 
--- SELECT * FROM get_reassurance_till_date(NOW());
+ALTER FUNCTION get_reassurance_till_date(_date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_reassurance_till_date(_chain_id uint256, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_reassurance_till_date(_chain_id uint256, _cover_key bytes32, _date TIMESTAMP WITH TIME ZONE ) OWNER TO writeuser;
 
+-- SELECT * FROM get_reassurance_till_date(NOW());
 
 CREATE OR REPLACE FUNCTION get_reporter_commission(_chain_id uint256)
 RETURNS numeric
@@ -7024,7 +7027,7 @@ CREATE OR REPLACE FUNCTION get_tvl_till_date
   _date                                     TIMESTAMP WITH TIME ZONE
 )
 RETURNS numeric
-IMMUTABLE
+STABLE
 AS
 $$
   DECLARE _result numeric;
@@ -7103,6 +7106,13 @@ BEGIN
 END
 $$
 LANGUAGE plpgsql;
+
+ALTER FUNCTION get_tvl_till_date( _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_tvl_till_date( _chain_id uint256, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_tvl_till_date( _chain_id uint256, _cover_key bytes32, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+
+-- SELECT * FROM get_tvl_till_date(NOW());
+
 CREATE OR REPLACE FUNCTION get_user_milestones
 (
   _account                        address

--- a/sql/base/003-functions/get_reassurance_till_date.sql
+++ b/sql/base/003-functions/get_reassurance_till_date.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION get_reassurance_till_date
   _date                                     TIMESTAMP WITH TIME ZONE
 )
 RETURNS numeric
-IMMUTABLE
+STABLE
 AS
 $$
   DECLARE _added numeric;
@@ -30,7 +30,7 @@ CREATE OR REPLACE FUNCTION get_reassurance_till_date
   _date                                     TIMESTAMP WITH TIME ZONE
 )
 RETURNS numeric
-IMMUTABLE
+STABLE
 AS
 $$
   DECLARE _added numeric;
@@ -60,7 +60,7 @@ CREATE OR REPLACE FUNCTION get_reassurance_till_date
   _date                                     TIMESTAMP WITH TIME ZONE
 )
 RETURNS numeric
-IMMUTABLE
+STABLE
 AS
 $$
   DECLARE _added numeric;
@@ -85,5 +85,8 @@ END
 $$
 LANGUAGE plpgsql;
 
--- SELECT * FROM get_reassurance_till_date(NOW());
+ALTER FUNCTION get_reassurance_till_date(_date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_reassurance_till_date(_chain_id uint256, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_reassurance_till_date(_chain_id uint256, _cover_key bytes32, _date TIMESTAMP WITH TIME ZONE ) OWNER TO writeuser;
 
+-- SELECT * FROM get_reassurance_till_date(NOW());

--- a/sql/base/003-functions/get_tvl_till_date.sql
+++ b/sql/base/003-functions/get_tvl_till_date.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION get_tvl_till_date
   _date                                     TIMESTAMP WITH TIME ZONE
 )
 RETURNS numeric
-IMMUTABLE
+STABLE
 AS
 $$
   DECLARE _result numeric;
@@ -82,3 +82,9 @@ BEGIN
 END
 $$
 LANGUAGE plpgsql;
+
+ALTER FUNCTION get_tvl_till_date( _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_tvl_till_date( _chain_id uint256, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+ALTER FUNCTION get_tvl_till_date( _chain_id uint256, _cover_key bytes32, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
+
+-- SELECT * FROM get_tvl_till_date(NOW());


### PR DESCRIPTION
```sql
CREATE OR REPLACE FUNCTION get_reassurance_till_date
(
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _added numeric;
  DECLARE _capitalized numeric;
BEGIN
  SELECT SUM(get_stablecoin_value(chain_id, amount))
  INTO _added
  FROM reassurance.reassurance_added
  WHERE to_timestamp(block_timestamp) <= _date;
  
  SELECT SUM(get_stablecoin_value(chain_id, amount))
  INTO _capitalized
  FROM reassurance.pool_capitalized
  WHERE to_timestamp(block_timestamp) <= _date;

  RETURN COALESCE(_added, 0) - COALESCE(_capitalized, 0);
END
$$
LANGUAGE plpgsql;

CREATE OR REPLACE FUNCTION get_reassurance_till_date
(
  _chain_id                                 uint256,
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _added numeric;
  DECLARE _capitalized numeric;
BEGIN
  SELECT SUM(get_stablecoin_value(chain_id, amount))
  INTO _added
  FROM reassurance.reassurance_added
  WHERE to_timestamp(block_timestamp) <= _date
  AND chain_id = _chain_id;
  
  SELECT SUM(get_stablecoin_value(chain_id, amount))
  INTO _capitalized
  FROM reassurance.pool_capitalized
  WHERE to_timestamp(block_timestamp) <= _date
  AND chain_id = _chain_id;

  RETURN COALESCE(_added, 0) - COALESCE(_capitalized, 0);
END
$$
LANGUAGE plpgsql;

CREATE OR REPLACE FUNCTION get_reassurance_till_date
(
  _chain_id                                 uint256,
  _cover_key                                bytes32,
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _added numeric;
  DECLARE _capitalized numeric;
BEGIN
  SELECT SUM(get_stablecoin_value(chain_id, amount))
  INTO _added
  FROM reassurance.reassurance_added
  WHERE to_timestamp(block_timestamp) <= _date
  AND chain_id = _chain_id
  AND cover_key = _cover_key;
  
  SELECT SUM(get_stablecoin_value(chain_id, amount))
  INTO _capitalized
  FROM reassurance.pool_capitalized
  WHERE to_timestamp(block_timestamp) <= _date
  AND chain_id = _chain_id
  AND cover_key = _cover_key;

  RETURN COALESCE(_added, 0) - COALESCE(_capitalized, 0);
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION get_reassurance_till_date(_date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION get_reassurance_till_date(_chain_id uint256, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION get_reassurance_till_date(_chain_id uint256, _cover_key bytes32, _date TIMESTAMP WITH TIME ZONE ) OWNER TO writeuser;

-- SELECT * FROM get_reassurance_till_date(NOW());

CREATE OR REPLACE FUNCTION get_tvl_till_date
(
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT SUM
  (
    get_stablecoin_value(core.transactions.chain_id, core.transactions.transaction_stablecoin_amount)
    *
    CASE WHEN core.transactions.event_name IN ('Claimed') THEN -1 ELSE 1 END
  )
  INTO _result
  FROM core.transactions
  WHERE core.transactions.event_name IN ('CoverPurchased', 'PodsIssued', 'PodsRedeemed', 'Claimed', 'PoolCapitalized')
  AND to_timestamp(core.transactions.block_timestamp) <= _date;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;

CREATE OR REPLACE FUNCTION get_tvl_till_date
(
  _chain_id                                 uint256,
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT SUM
  (
    get_stablecoin_value(core.transactions.chain_id, core.transactions.transaction_stablecoin_amount)
    *
    CASE WHEN core.transactions.event_name IN ('Claimed') THEN -1 ELSE 1 END
  )
  INTO _result
  FROM core.transactions
  WHERE core.transactions.chain_id = _chain_id
  AND core.transactions.event_name IN ('CoverPurchased', 'PodsIssued', 'PodsRedeemed', 'Claimed', 'PoolCapitalized')
  AND to_timestamp(core.transactions.block_timestamp) <= _date;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;


CREATE OR REPLACE FUNCTION get_tvl_till_date
(
  _chain_id                                 uint256,
  _cover_key                                bytes32,
  _date                                     TIMESTAMP WITH TIME ZONE
)
RETURNS numeric
STABLE
AS
$$
  DECLARE _result numeric;
BEGIN
  SELECT SUM
  (    
    get_stablecoin_value(core.transactions.chain_id, core.transactions.transaction_stablecoin_amount)
    *
    CASE WHEN core.transactions.event_name IN ('Claimed') THEN -1 ELSE 1 END
  )
  INTO _result
  FROM core.transactions
  WHERE core.transactions.chain_id = _chain_id
  AND core.transactions.ck = _cover_key
  AND core.transactions.event_name IN ('CoverPurchased', 'PodsIssued', 'PodsRedeemed', 'Claimed', 'PoolCapitalized')
  AND to_timestamp(core.transactions.block_timestamp) <= _date;

  RETURN COALESCE(_result, 0);
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION get_tvl_till_date( _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION get_tvl_till_date( _chain_id uint256, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;
ALTER FUNCTION get_tvl_till_date( _chain_id uint256, _cover_key bytes32, _date TIMESTAMP WITH TIME ZONE) OWNER TO writeuser;

-- SELECT * FROM get_tvl_till_date(NOW());

ROLLBACK TRANSACTION;
```