### PR TITLE
Convert materialized views to regular views

### DIFF
--- a/sql/base/001-materialized-views/reassurance_transaction_view.sql
+++ b/sql/base/001-materialized-views/reassurance_transaction_view.sql
@@ -1,6 +1,4 @@
-DROP MATERIALIZED VIEW IF EXISTS reassurance_transaction_view CASCADE;
-
-CREATE MATERIALIZED VIEW reassurance_transaction_view
+CREATE OR REPLACE VIEW reassurance_transaction_view
 AS
 SELECT
   'Reassurance Added' AS description,  
@@ -22,28 +20,4 @@ GROUP BY
   reassurance.pool_capitalized.chain_id,
   reassurance.pool_capitalized.cover_key;
 
-CREATE UNIQUE INDEX description_chain_id_cover_key_reassurance_transaction_view
-ON reassurance_transaction_view(description, chain_id, cover_key);
-
-CREATE INDEX chain_id_cover_key_reassurance_transaction_view_inx
-ON reassurance_transaction_view(chain_id, cover_key);
-
-
-DROP FUNCTION IF EXISTS core.refresh_reassurance_transaction_view_trigger() CASCADE;
-
-CREATE FUNCTION core.refresh_reassurance_transaction_view_trigger()
-RETURNS trigger
-AS
-$$
-BEGIN
-  REFRESH MATERIALIZED VIEW CONCURRENTLY public.reassurance_transaction_view;
-  RETURN NEW;
-END
-$$
-LANGUAGE plpgsql;
-
-
-CREATE TRIGGER refresh_reassurance_transaction_view_trigger
-BEFORE INSERT OR UPDATE ON core.transactions
-FOR EACH STATEMENT
-EXECUTE FUNCTION core.refresh_reassurance_transaction_view_trigger();
+ALTER VIEW reassurance_transaction_view OWNER TO writeuser;

--- a/sql/base/001-materialized-views/stablecoin_transactions_view.sql
+++ b/sql/base/001-materialized-views/stablecoin_transactions_view.sql
@@ -1,6 +1,4 @@
-DROP MATERIALIZED VIEW IF EXISTS stablecoin_transactions_view CASCADE;
-
-CREATE MATERIALIZED VIEW stablecoin_transactions_view
+CREATE OR REPLACE VIEW stablecoin_transactions_view
 AS
 WITH transactions
 AS
@@ -42,30 +40,4 @@ AS
 SELECT description, chain_id, cover_key, total
 FROM transactions;
 
-
-CREATE UNIQUE INDEX description_chain_id_cover_key_stablecoin_transactions_view
-ON stablecoin_transactions_view(description, chain_id, cover_key);
-
-CREATE INDEX chain_id_cover_key_stablecoin_transactions_view_inx
-ON stablecoin_transactions_view(chain_id, cover_key);
-
-
-DROP FUNCTION IF EXISTS core.refresh_stablecoin_transactions_view_trigger() CASCADE;
-
-CREATE FUNCTION core.refresh_stablecoin_transactions_view_trigger()
-RETURNS trigger
-AS
-$$
-BEGIN
-  REFRESH MATERIALIZED VIEW CONCURRENTLY public.stablecoin_transactions_view;
-  RETURN NEW;
-END
-$$
-LANGUAGE plpgsql;
-
-
-CREATE TRIGGER refresh_stablecoin_transactions_view_trigger
-BEFORE INSERT OR UPDATE ON core.transactions
-FOR EACH STATEMENT
-EXECUTE FUNCTION core.refresh_stablecoin_transactions_view_trigger();
-
+ALTER VIEW stablecoin_transactions_view OWNER TO writeuser;

--- a/sql/base/002-views/cover_reassurance_view.sql
+++ b/sql/base/002-views/cover_reassurance_view.sql
@@ -1,8 +1,7 @@
-DROP VIEW IF EXISTS cover_reassurance_view;
-
-CREATE VIEW cover_reassurance_view
+CREATE OR REPLACE VIEW cover_reassurance_view
 AS
 SELECT chain_id, cover_key, SUM(total) AS reassurance
 FROM reassurance_transaction_view
 GROUP BY chain_id, cover_key;
 
+ALTER VIEW cover_reassurance_view OWNER TO writeuser;

--- a/sql/base/002-views/total_fee_earned_view.sql
+++ b/sql/base/002-views/total_fee_earned_view.sql
@@ -1,7 +1,6 @@
-DROP VIEW IF EXISTS total_fee_earned_view;
-
-CREATE VIEW total_fee_earned_view
+CREATE OR REPLACE VIEW total_fee_earned_view
 AS
 SELECT * FROM stablecoin_transactions_view
 WHERE description = 'Fee Earned';
 
+ALTER VIEW total_fee_earned_view OWNER TO writeuser;

--- a/sql/base/002-views/total_liquidity_added_view.sql
+++ b/sql/base/002-views/total_liquidity_added_view.sql
@@ -1,6 +1,6 @@
-DROP VIEW IF EXISTS total_liquidity_added_view;
-
-CREATE VIEW total_liquidity_added_view
+CREATE OR REPLACE VIEW total_liquidity_added_view
 AS
 SELECT * FROM stablecoin_transactions_view
 WHERE description = 'Liquidity Added';
+
+ALTER VIEW total_liquidity_added_view OWNER TO writeuser;

--- a/sql/base/002-views/total_liquidity_removed_view.sql
+++ b/sql/base/002-views/total_liquidity_removed_view.sql
@@ -1,7 +1,6 @@
-DROP VIEW IF EXISTS total_liquidity_removed_view;
-
-CREATE VIEW total_liquidity_removed_view
+CREATE OR REPLACE VIEW total_liquidity_removed_view
 AS
 SELECT * FROM stablecoin_transactions_view
 WHERE description = 'Liquidity Removed';
 
+ALTER VIEW total_liquidity_removed_view OWNER TO writeuser;

--- a/sql/base/002-views/total_value_locked_by_chain_view.sql
+++ b/sql/base/002-views/total_value_locked_by_chain_view.sql
@@ -1,7 +1,7 @@
-DROP VIEW IF EXISTS total_value_locked_by_chain_view;
-
-CREATE VIEW total_value_locked_by_chain_view
+CREATE OR REPLACE VIEW total_value_locked_by_chain_view
 AS
 SELECT chain_id, sum(total) as total
 FROM stablecoin_transactions_view
 GROUP by chain_id;
+
+ALTER VIEW total_value_locked_by_chain_view OWNER TO writeuser;

--- a/sql/base/002-views/total_value_locked_view.sql
+++ b/sql/base/002-views/total_value_locked_view.sql
@@ -1,7 +1,6 @@
-DROP VIEW IF EXISTS total_value_locked_view;
-
-CREATE VIEW total_value_locked_view
+CREATE OR REPLACE VIEW total_value_locked_view
 AS
 SELECT sum(total) as total
 FROM stablecoin_transactions_view;
 
+ALTER VIEW total_value_locked_view OWNER TO writeuser;

--- a/sql/util/convert_materialized_view_to_regular_view.sql
+++ b/sql/util/convert_materialized_view_to_regular_view.sql
@@ -13,8 +13,9 @@ BEGIN
   (
     SELECT DISTINCT pg_describe_object(classid, objid, objsubid)    AS dependency
     FROM pg_depend
-    WHERE refobjid = materialized_view::regclass
-    AND deptype = 'n'
+    WHERE 1 = 1
+    AND refobjid  = materialized_view::regclass
+    AND deptype   = 'n'
   ),
   all_views
   AS
@@ -34,7 +35,8 @@ BEGIN
 
   FOREACH _r IN ARRAY _dependencies
   LOOP
-    _dependency_codes:= _dependency_codes|| pg_get_viewdef(_r, true);
+    _dependency_codes := _dependency_codes|| pg_get_viewdef(_r, true);
+
     _sql = CONCAT(E'\n', _sql, format('DROP VIEW %I;', _r));
   END LOOP;
 

--- a/sql/util/convert_materialized_view_to_regular_view.sql
+++ b/sql/util/convert_materialized_view_to_regular_view.sql
@@ -1,0 +1,65 @@
+CREATE OR REPLACE FUNCTION convert_materialized_view_to_regular_view(materialized_view text)
+RETURNS void
+AS
+$$
+  DECLARE _dependencies                                             text[];
+  DECLARE _dependency_codes                                         text[];
+  DECLARE _mv_code                                                  text;
+  DECLARE _r                                                        text;
+  DECLARE _sql                                                      text = '';
+BEGIN
+  WITH dependencies
+  AS
+  (
+    SELECT DISTINCT pg_describe_object(classid, objid, objsubid)    AS dependency
+    FROM pg_depend
+    WHERE refobjid = materialized_view::regclass
+    AND deptype = 'n'
+  ),
+  all_views
+  AS
+  (
+    SELECT REPLACE(dependency, 'rule _RETURN on view ', '')         AS dependency
+    FROM dependencies
+  ),
+  views_to_drop
+  AS
+  (
+    SELECT ARRAY_AGG(dependency)                                    AS dependencies
+    FROM all_views
+  )
+  SELECT dependencies
+  INTO _dependencies
+  FROM views_to_drop;
+
+  FOREACH _r IN ARRAY _dependencies
+  LOOP
+    _dependency_codes:= _dependency_codes|| pg_get_viewdef(_r, true);
+    _sql = CONCAT(E'\n', _sql, format('DROP VIEW %I;', _r));
+  END LOOP;
+
+  _mv_code := pg_get_viewdef(materialized_view::regclass, true);
+
+  _sql = CONCAT(E'\n', _sql, format('DROP MATERIALIZED VIEW %I;', materialized_view::regclass));
+
+  _sql = CONCAT(E'\n', _sql, format(E'CREATE VIEW %I AS\n%s;', materialized_view::regclass, _mv_code));
+
+
+  FOR i IN 1..array_length(_dependencies, 1)
+  LOOP
+    _sql = CONCAT
+    (
+      E'\n',
+      _sql,
+      format(E'SET search_path TO public; CREATE VIEW %I AS\n%s;', _dependencies[i], _dependency_codes[i])
+    );
+  END LOOP;
+
+  RAISE NOTICE '%', _sql;
+
+  EXECUTE _sql;
+END
+$$
+LANGUAGE plpgsql;
+
+ALTER FUNCTION convert_materialized_view_to_regular_view OWNER TO writeuser;


### PR DESCRIPTION
- Converted materialized views to regular views
- Updated dependent views
- Added util to convert all materialized views to regular views

```sql
DROP VIEW IF EXISTS total_fee_earned_view;
DROP VIEW IF EXISTS total_liquidity_added_view;
DROP VIEW IF EXISTS total_liquidity_removed_view;
DROP VIEW IF EXISTS total_value_locked_by_chain_view;
DROP VIEW IF EXISTS total_value_locked_view;
DROP VIEW IF EXISTS cover_reassurance_view;

DROP MATERIALIZED VIEW IF EXISTS reassurance_transaction_view;
DROP MATERIALIZED VIEW IF EXISTS stablecoin_transactions_view;

DROP TRIGGER refresh_reassurance_transaction_view_trigger ON core.transactions;
DROP TRIGGER refresh_stablecoin_transactions_view_trigger ON core.transactions;

DROP FUNCTION IF EXISTS core.refresh_reassurance_transaction_view_trigger();

DROP FUNCTION IF EXISTS core.refresh_stablecoin_transactions_view_trigger();

CREATE OR REPLACE VIEW reassurance_transaction_view
AS
SELECT
  'Reassurance Added' AS description,  
  reassurance.reassurance_added.chain_id,
  reassurance.reassurance_added.cover_key,
  SUM(get_stablecoin_value(reassurance.reassurance_added.chain_id, reassurance.reassurance_added.amount)) AS total
FROM reassurance.reassurance_added
GROUP BY 
  reassurance.reassurance_added.chain_id,
  reassurance.reassurance_added.cover_key
UNION ALL
SELECT
  'Pool Capitalized' AS description,  
  reassurance.pool_capitalized.chain_id,
  reassurance.pool_capitalized.cover_key,
  SUM(get_stablecoin_value(reassurance.pool_capitalized.chain_id, reassurance.pool_capitalized.amount)) * -1
FROM reassurance.pool_capitalized
GROUP BY 
  reassurance.pool_capitalized.chain_id,
  reassurance.pool_capitalized.cover_key;

ALTER VIEW reassurance_transaction_view OWNER TO writeuser;

CREATE OR REPLACE VIEW stablecoin_transactions_view
AS
WITH transactions
AS
(
  SELECT
    'Liquidity Added' AS description,
    vault.pods_issued.chain_id,
    factory.vault_deployed.cover_key,
    SUM(get_stablecoin_value(vault.pods_issued.chain_id, vault.pods_issued.liquidity_added)) as total
  FROM vault.pods_issued
  INNER JOIN factory.vault_deployed
  ON factory.vault_deployed.vault = vault.pods_issued.address
  AND factory.vault_deployed.chain_id = vault.pods_issued.chain_id
  GROUP BY vault.pods_issued.chain_id, factory.vault_deployed.cover_key

  UNION ALL

  SELECT
    'Liquidity Removed' AS description,
    vault.pods_redeemed.chain_id,
    factory.vault_deployed.cover_key,
    SUM(get_stablecoin_value(vault.pods_redeemed.chain_id, vault.pods_redeemed.liquidity_released)) as total_liquidity
  FROM vault.pods_redeemed
  INNER JOIN factory.vault_deployed
  ON factory.vault_deployed.vault = vault.pods_redeemed.address
  AND factory.vault_deployed.chain_id = vault.pods_redeemed.chain_id
  GROUP BY vault.pods_redeemed.chain_id, factory.vault_deployed.cover_key

  UNION ALL

  SELECT
    'Fee Earned' AS description,
    chain_id,
    cover_key,
    SUM(get_stablecoin_value(chain_id, fee - platform_fee)) AS total_fee
  FROM policy.cover_purchased
  GROUP BY chain_id, cover_key
)
SELECT description, chain_id, cover_key, total
FROM transactions;

ALTER VIEW stablecoin_transactions_view OWNER TO writeuser;

CREATE OR REPLACE VIEW total_fee_earned_view
AS
SELECT * FROM stablecoin_transactions_view
WHERE description = 'Fee Earned';

ALTER VIEW total_fee_earned_view OWNER TO writeuser;

CREATE OR REPLACE VIEW total_liquidity_added_view
AS
SELECT * FROM stablecoin_transactions_view
WHERE description = 'Liquidity Added';

ALTER VIEW total_liquidity_added_view OWNER TO writeuser;

CREATE OR REPLACE VIEW total_liquidity_removed_view
AS
SELECT * FROM stablecoin_transactions_view
WHERE description = 'Liquidity Removed';

ALTER VIEW total_liquidity_removed_view OWNER TO writeuser;

CREATE OR REPLACE VIEW total_value_locked_by_chain_view
AS
SELECT chain_id, sum(total) as total
FROM stablecoin_transactions_view
GROUP by chain_id;

ALTER VIEW total_value_locked_by_chain_view OWNER TO writeuser;

CREATE OR REPLACE VIEW total_value_locked_view
AS
SELECT sum(total) as total
FROM stablecoin_transactions_view;

ALTER VIEW total_value_locked_view OWNER TO writeuser;

CREATE OR REPLACE VIEW cover_reassurance_view
AS
SELECT chain_id, cover_key, SUM(total) AS reassurance
FROM reassurance_transaction_view
GROUP BY chain_id, cover_key;

ALTER VIEW cover_reassurance_view OWNER TO writeuser;

ROLLBACK TRANSACTION;
```

## Update Ownerships (Optional)

```sql
DO
$$
  DECLARE _r record;
BEGIN
  FOR _r IN
    SELECT table_schema, table_name
    FROM information_schema.tables
    WHERE table_schema NOT IN('information_schema', 'pg_catalog')
    ORDER BY table_schema, table_name
  LOOP
    EXECUTE format('ALTER TABLE %I.%I OWNER TO writeuser;', _r.table_schema, _r.table_name);
  END LOOP;

  FOR _r IN
    SELECT table_schema, table_name
    FROM information_schema.views
    WHERE table_schema NOT IN ('information_schema', 'pg_catalog')
    ORDER BY table_schema, table_name
  LOOP
    EXECUTE format('ALTER VIEW %I.%I OWNER TO writeuser;', _r.table_schema, _r.table_name);
  END LOOP;

  FOR _r IN
    SELECT CONCAT(n.nspname, '.', p.proname, '(', pg_catalog.pg_get_function_identity_arguments(p.oid), ')') AS name
    FROM pg_catalog.pg_proc p
    INNER JOIN pg_catalog.pg_namespace n
    ON n.oid = p.pronamespace
    WHERE pg_catalog.pg_function_is_visible(p.oid)
    AND n.nspname NOT IN ('information_schema', 'pg_catalog')
    AND NOT p.proisstrict
  LOOP
    EXECUTE format('ALTER FUNCTION %s OWNER TO writeuser;', _r.name);
  END LOOP;
END
$$
LANGUAGE plpgsql;
```
