### PR TITLE
Fixes

### DIFF
--- a/build/db.sql
+++ b/build/db.sql
@@ -7996,8 +7996,12 @@ BEGIN
   UPDATE _get_historical_apr_by_cover_chart_data_result
   SET
     policy_fee_earned = sum_cover_fee_earned_during(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.start_date, _get_historical_apr_by_cover_chart_data_result.end_date),
-    duration          = EXTRACT(DAY FROM (_get_historical_apr_by_cover_chart_data_result.end_date - _get_historical_apr_by_cover_chart_data_result.start_date))::integer,
-    end_balance       = get_tvl_till_date(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.end_date);
+    end_balance       = get_tvl_till_date(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.end_date),
+    duration          = CEIL
+    (
+      EXTRACT(EPOCH FROM (_get_historical_apr_by_cover_chart_data_result.end_date - _get_historical_apr_by_cover_chart_data_result.start_date)) /
+      EXTRACT(EPOCH FROM INTERVAL '1 day')
+    );
 
   UPDATE _get_historical_apr_by_cover_chart_data_result
   SET apr             = (_get_historical_apr_by_cover_chart_data_result.policy_fee_earned * 365) / (average(_get_historical_apr_by_cover_chart_data_result.start_balance, _get_historical_apr_by_cover_chart_data_result.end_balance) * _get_historical_apr_by_cover_chart_data_result.duration)
@@ -8075,7 +8079,11 @@ BEGIN
   UPDATE _get_historical_apr_chart_data_result
   SET
     policy_fee_earned = sum_cover_fee_earned_during(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.start_date, _get_historical_apr_chart_data_result.end_date),
-    duration          = EXTRACT(DAY FROM (_get_historical_apr_chart_data_result.end_date - _get_historical_apr_chart_data_result.start_date))::integer;
+    duration          = CEIL
+    (
+      EXTRACT(EPOCH FROM (_get_historical_apr_chart_data_result.end_date - _get_historical_apr_chart_data_result.start_date)) /
+      EXTRACT(EPOCH FROM INTERVAL '1 day')
+    );
 
   UPDATE _get_historical_apr_chart_data_result
   SET apr             = (_get_historical_apr_chart_data_result.policy_fee_earned * 365) / (_get_historical_apr_chart_data_result.start_balance * _get_historical_apr_chart_data_result.duration)
@@ -8870,7 +8878,7 @@ AS
     transaction_hash,
     account                                             AS account,
     wei_to_ether(amount)                                AS cxtoken_amount,
-    wei_to_ether(claimed)                               AS stablecoin_amount,
+    get_stablecoin_value(chain_id, claimed)             AS stablecoin_amount,
     'Claimed'                                           AS tx_type
   FROM cxtoken.claimed
 )
@@ -8886,16 +8894,16 @@ SELECT
   policy_txs.cxtoken_amount,
   policy_txs.stablecoin_amount,
   policy_txs.tx_type,
-  bytes32_to_string(policy_txs.cover_key)       AS cover_key_string,
-  bytes32_to_string(policy_txs.product_key)     AS product_key_string,
-  'cxUSD'                                       AS token_symbol,
+  bytes32_to_string(policy_txs.cover_key)               AS cover_key_string,
+  bytes32_to_string(policy_txs.product_key)             AS product_key_string,
+  'cxUSD'                                               AS token_symbol,
   factory.cx_token_deployed.token_name
 FROM policy_txs
 INNER JOIN factory.cx_token_deployed
-ON factory.cx_token_deployed.chain_id           = policy_txs.chain_id
-AND factory.cx_token_deployed.cover_key         = policy_txs.cover_key
-AND factory.cx_token_deployed.product_key       = policy_txs.product_key
-AND factory.cx_token_deployed.cx_token          = policy_txs.cx_token;
+ON factory.cx_token_deployed.chain_id                   = policy_txs.chain_id
+AND factory.cx_token_deployed.cover_key                 = policy_txs.cover_key
+AND factory.cx_token_deployed.product_key               = policy_txs.product_key
+AND factory.cx_token_deployed.cx_token                  = policy_txs.cx_token;
 
 ALTER VIEW my_policies_view OWNER TO writeuser;
 

--- a/sql/app/home/get_historical_apr_by_cover_chart_data.sql
+++ b/sql/app/home/get_historical_apr_by_cover_chart_data.sql
@@ -66,8 +66,12 @@ BEGIN
   UPDATE _get_historical_apr_by_cover_chart_data_result
   SET
     policy_fee_earned = sum_cover_fee_earned_during(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.start_date, _get_historical_apr_by_cover_chart_data_result.end_date),
-    duration          = EXTRACT(DAY FROM (_get_historical_apr_by_cover_chart_data_result.end_date - _get_historical_apr_by_cover_chart_data_result.start_date))::integer,
-    end_balance       = get_tvl_till_date(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.end_date);
+    end_balance       = get_tvl_till_date(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.end_date),
+    duration          = CEIL
+    (
+      EXTRACT(EPOCH FROM (_get_historical_apr_by_cover_chart_data_result.end_date - _get_historical_apr_by_cover_chart_data_result.start_date)) /
+      EXTRACT(EPOCH FROM INTERVAL '1 day')
+    );
 
   UPDATE _get_historical_apr_by_cover_chart_data_result
   SET apr             = (_get_historical_apr_by_cover_chart_data_result.policy_fee_earned * 365) / (average(_get_historical_apr_by_cover_chart_data_result.start_balance, _get_historical_apr_by_cover_chart_data_result.end_balance) * _get_historical_apr_by_cover_chart_data_result.duration)

--- a/sql/app/home/get_historical_apr_chart_data.sql
+++ b/sql/app/home/get_historical_apr_chart_data.sql
@@ -54,7 +54,11 @@ BEGIN
   UPDATE _get_historical_apr_chart_data_result
   SET
     policy_fee_earned = sum_cover_fee_earned_during(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.start_date, _get_historical_apr_chart_data_result.end_date),
-    duration          = EXTRACT(DAY FROM (_get_historical_apr_chart_data_result.end_date - _get_historical_apr_chart_data_result.start_date))::integer;
+    duration          = CEIL
+    (
+      EXTRACT(EPOCH FROM (_get_historical_apr_chart_data_result.end_date - _get_historical_apr_chart_data_result.start_date)) /
+      EXTRACT(EPOCH FROM INTERVAL '1 day')
+    );
 
   UPDATE _get_historical_apr_chart_data_result
   SET apr             = (_get_historical_apr_chart_data_result.policy_fee_earned * 365) / (_get_historical_apr_chart_data_result.start_balance * _get_historical_apr_chart_data_result.duration)

--- a/sql/app/policy/my_policies_view.sql
+++ b/sql/app/policy/my_policies_view.sql
@@ -25,7 +25,7 @@ AS
     transaction_hash,
     account                                             AS account,
     wei_to_ether(amount)                                AS cxtoken_amount,
-    wei_to_ether(claimed)                               AS stablecoin_amount,
+    get_stablecoin_value(chain_id, claimed)             AS stablecoin_amount,
     'Claimed'                                           AS tx_type
   FROM cxtoken.claimed
 )
@@ -41,15 +41,15 @@ SELECT
   policy_txs.cxtoken_amount,
   policy_txs.stablecoin_amount,
   policy_txs.tx_type,
-  bytes32_to_string(policy_txs.cover_key)       AS cover_key_string,
-  bytes32_to_string(policy_txs.product_key)     AS product_key_string,
-  'cxUSD'                                       AS token_symbol,
+  bytes32_to_string(policy_txs.cover_key)               AS cover_key_string,
+  bytes32_to_string(policy_txs.product_key)             AS product_key_string,
+  'cxUSD'                                               AS token_symbol,
   factory.cx_token_deployed.token_name
 FROM policy_txs
 INNER JOIN factory.cx_token_deployed
-ON factory.cx_token_deployed.chain_id           = policy_txs.chain_id
-AND factory.cx_token_deployed.cover_key         = policy_txs.cover_key
-AND factory.cx_token_deployed.product_key       = policy_txs.product_key
-AND factory.cx_token_deployed.cx_token          = policy_txs.cx_token;
+ON factory.cx_token_deployed.chain_id                   = policy_txs.chain_id
+AND factory.cx_token_deployed.cover_key                 = policy_txs.cover_key
+AND factory.cx_token_deployed.product_key               = policy_txs.product_key
+AND factory.cx_token_deployed.cx_token                  = policy_txs.cx_token;
 
 ALTER VIEW my_policies_view OWNER TO writeuser;


### PR DESCRIPTION
- Fixed month duration calculation
- Fixed stablecoin format

```sql
CREATE OR REPLACE FUNCTION get_historical_apr_chart_data()
RETURNS TABLE
(
  chain_id                                    uint256,
  network_name                                text,
  start_date                                  TIMESTAMP WITH TIME ZONE,
  end_date                                    TIMESTAMP WITH TIME ZONE,
  duration                                    integer,
  period_name                                 text,
  start_balance                               numeric,
  policy_fee_earned                           numeric,
  apr                                         numeric
)
AS
$$
BEGIN
  CREATE TEMPORARY TABLE _get_historical_apr_chart_data_result
  (
    chain_id                                  uint256,
    network_name                              text,
    start_date                                TIMESTAMP WITH TIME ZONE,
    end_date                                  TIMESTAMP WITH TIME ZONE,
    duration                                  integer,
    period_name                               text,
    start_balance                             numeric,
    policy_fee_earned                         numeric,
    apr                                       NUMERIC DEFAULT(0)
  ) ON COMMIT DROP;


  INSERT INTO _get_historical_apr_chart_data_result(chain_id, start_date)
  WITH dates
  AS
  (
    SELECT date_trunc('month', generate_series((SELECT to_timestamp(MIN(block_timestamp))::date FROM core.transactions), NOW() AT TIME ZONE 'UTC', '1 month'))
  )
  SELECT DISTINCT
    core.transactions.chain_id,
    dates.*
  FROM core.transactions
  CROSS JOIN dates;


  UPDATE _get_historical_apr_chart_data_result
  SET
    end_date          = (_get_historical_apr_chart_data_result.start_date + '1 month'::interval - '1 millisecond'::interval),
    period_name       = to_char(_get_historical_apr_chart_data_result.start_date, 'Mon-YY'),
    start_balance     = get_tvl_till_date(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.start_date);

  UPDATE _get_historical_apr_chart_data_result
  SET end_date        = NOW()
  WHERE _get_historical_apr_chart_data_result.end_date > NOW();

  UPDATE _get_historical_apr_chart_data_result
  SET
    policy_fee_earned = sum_cover_fee_earned_during(_get_historical_apr_chart_data_result.chain_id, _get_historical_apr_chart_data_result.start_date, _get_historical_apr_chart_data_result.end_date),
    duration          = CEIL
    (
      EXTRACT(EPOCH FROM (_get_historical_apr_chart_data_result.end_date - _get_historical_apr_chart_data_result.start_date)) /
      EXTRACT(EPOCH FROM INTERVAL '1 day')
    );

  UPDATE _get_historical_apr_chart_data_result
  SET apr             = (_get_historical_apr_chart_data_result.policy_fee_earned * 365) / (_get_historical_apr_chart_data_result.start_balance * _get_historical_apr_chart_data_result.duration)
  WHERE _get_historical_apr_chart_data_result.start_balance > 0;

  UPDATE _get_historical_apr_chart_data_result
  SET network_name    = config_blockchain_network_view.nick_name
  FROM config_blockchain_network_view
  WHERE config_blockchain_network_view.chain_id = _get_historical_apr_chart_data_result.chain_id;

  RETURN QUERY
  SELECT * FROM _get_historical_apr_chart_data_result
  ORDER BY 2, 1;
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION get_historical_apr_chart_data OWNER TO writeuser;

CREATE OR REPLACE FUNCTION get_historical_apr_by_cover_chart_data()
RETURNS TABLE
(
  chain_id                                    uint256,
  network_name                                text,
  cover_key                                   bytes32,
  cover_key_string                            text,
  start_date                                  TIMESTAMP WITH TIME ZONE,
  end_date                                    TIMESTAMP WITH TIME ZONE,
  duration                                    integer,
  period_name                                 text,
  start_balance                               numeric,
  end_balance                                 numeric,
  policy_fee_earned                           numeric,
  apr                                         numeric
)
AS
$$
BEGIN
  CREATE TEMPORARY TABLE _get_historical_apr_by_cover_chart_data_result
  (
    chain_id                                  uint256,
    network_name                              text,
    cover_key                                 bytes32,
    cover_key_string                          text,
    start_date                                TIMESTAMP WITH TIME ZONE,
    end_date                                  TIMESTAMP WITH TIME ZONE,
    duration                                  integer,
    period_name                               text,
    start_balance                             numeric,
    end_balance                               numeric,
    policy_fee_earned                         numeric,
    apr                                       NUMERIC DEFAULT(0)
  ) ON COMMIT DROP;


  INSERT INTO _get_historical_apr_by_cover_chart_data_result(chain_id, cover_key, start_date)
  WITH dates
  AS
  (
    SELECT date_trunc
    (
      'month',
      generate_series((SELECT to_timestamp(MIN(block_timestamp))::date FROM core.transactions), NOW() AT TIME ZONE 'UTC', '1 month')
    )
  )
  SELECT DISTINCT
    core.transactions.chain_id,
    core.transactions.ck,
    dates.*
  FROM core.transactions
  CROSS JOIN dates
  WHERE core.transactions.ck IS NOT NULL;

  UPDATE _get_historical_apr_by_cover_chart_data_result
  SET
    cover_key_string  = bytes32_to_string(_get_historical_apr_by_cover_chart_data_result.cover_key),
    end_date          = (_get_historical_apr_by_cover_chart_data_result.start_date + '1 month'::interval - '1 millisecond'::interval),
    period_name       = to_char(_get_historical_apr_by_cover_chart_data_result.start_date, 'Mon-YY'),
    start_balance     = get_tvl_till_date(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.start_date);

  UPDATE _get_historical_apr_by_cover_chart_data_result
  SET end_date        = NOW()
  WHERE _get_historical_apr_by_cover_chart_data_result.end_date > NOW();

  UPDATE _get_historical_apr_by_cover_chart_data_result
  SET
    policy_fee_earned = sum_cover_fee_earned_during(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.start_date, _get_historical_apr_by_cover_chart_data_result.end_date),
    end_balance       = get_tvl_till_date(_get_historical_apr_by_cover_chart_data_result.chain_id, _get_historical_apr_by_cover_chart_data_result.cover_key, _get_historical_apr_by_cover_chart_data_result.end_date),
    duration          = CEIL
    (
      EXTRACT(EPOCH FROM (_get_historical_apr_by_cover_chart_data_result.end_date - _get_historical_apr_by_cover_chart_data_result.start_date)) /
      EXTRACT(EPOCH FROM INTERVAL '1 day')
    );

  UPDATE _get_historical_apr_by_cover_chart_data_result
  SET apr             = (_get_historical_apr_by_cover_chart_data_result.policy_fee_earned * 365) / (average(_get_historical_apr_by_cover_chart_data_result.start_balance, _get_historical_apr_by_cover_chart_data_result.end_balance) * _get_historical_apr_by_cover_chart_data_result.duration)
  WHERE _get_historical_apr_by_cover_chart_data_result.start_balance > 0;

  UPDATE _get_historical_apr_by_cover_chart_data_result
  SET network_name    = config_blockchain_network_view.nick_name
  FROM config_blockchain_network_view
  WHERE config_blockchain_network_view.chain_id = _get_historical_apr_by_cover_chart_data_result.chain_id;

  RETURN QUERY
  SELECT * FROM _get_historical_apr_by_cover_chart_data_result
  ORDER BY 2, 1;
END
$$
LANGUAGE plpgsql;

ALTER FUNCTION get_historical_apr_by_cover_chart_data OWNER TO writeuser;

CREATE OR REPLACE VIEW my_policies_view
AS
WITH policy_txs
AS
(
  SELECT
    chain_id,
    cover_key,
    product_key,
    block_timestamp,
    cx_token,
    transaction_hash,
    on_behalf_of                                        AS account,
    get_stablecoin_value(chain_id, amount_to_cover)     AS cxtoken_amount,
    get_stablecoin_value(chain_id, fee)                 AS stablecoin_amount,
    'CoverPurchased'                                    AS tx_type
  FROM policy.cover_purchased
  UNION ALL
  SELECT
    chain_id,
    cover_key,
    product_key,
    block_timestamp,
    cx_token,
    transaction_hash,
    account                                             AS account,
    wei_to_ether(amount)                                AS cxtoken_amount,
    get_stablecoin_value(chain_id, claimed)             AS stablecoin_amount,
    'Claimed'                                           AS tx_type
  FROM cxtoken.claimed
)

SELECT
  policy_txs.chain_id,
  policy_txs.cover_key,
  policy_txs.product_key,
  policy_txs.block_timestamp,
  policy_txs.cx_token,
  policy_txs.transaction_hash,
  policy_txs.account,
  policy_txs.cxtoken_amount,
  policy_txs.stablecoin_amount,
  policy_txs.tx_type,
  bytes32_to_string(policy_txs.cover_key)               AS cover_key_string,
  bytes32_to_string(policy_txs.product_key)             AS product_key_string,
  'cxUSD'                                               AS token_symbol,
  factory.cx_token_deployed.token_name
FROM policy_txs
INNER JOIN factory.cx_token_deployed
ON factory.cx_token_deployed.chain_id                   = policy_txs.chain_id
AND factory.cx_token_deployed.cover_key                 = policy_txs.cover_key
AND factory.cx_token_deployed.product_key               = policy_txs.product_key
AND factory.cx_token_deployed.cx_token                  = policy_txs.cx_token;

ALTER VIEW my_policies_view OWNER TO writeuser;

ROLLBACK TRANSACTION;
```